### PR TITLE
Handler type parameters must be specified to avoid error at next build

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -51,6 +51,6 @@ export function ironSession(
 ): (req: any, res: any, next: any) => void;
 
 export function withIronSession(
-  handler: Handler,
+  handler: Handler<any, any>,
   sessionOptions: SessionOptions,
 ): (...args: any[]) => Promise<any>;


### PR DESCRIPTION
When running
```
yarn run next build
```

The build fails with:

```
Failed to compile.

./node_modules/next-iron-session/lib/index.d.ts:54:12
Type error: Generic type 'Handler' requires 2 type argument(s).

  52 | 
  53 | export function withIronSession(
> 54 |   handler: Handler,
     |            ^
  55 |   sessionOptions: SessionOptions,
  56 | ): (...args: any[]) => Promise<any>;
  57 | 
````

---

### Using deps:
- next@11.0.1
- next-iron-session@4.2.0
- typescript@4.3.4