### PR TITLE
docs: redundant closing parenthesis in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ async function loginRoute(req, res) {
     };
     await req.session.save();
     res.send({ ok: true });
-  }
-);
+}
 ```
 
 ```ts


### PR DESCRIPTION
There is a redundant closing parenthesis in the **Advanced usage** section in the project `README.md`.