### PR TITLE
chore(pkg): add repository key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node.js stateless session utility using signed and encrypted cookies to store data. Works with Next.js, Express, NestJs, Fastify, and any Node.js HTTP framework.",
   "license": "MIT",
   "author": "Vincent Voyer <vincent@codeagain.com>",
+  "repository": "github:vvo/iron-session",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
Add `repository` key in `package.json`.

This means that the right-hand bar on https://www.npmjs.com/package/iron-session will show a link to the repository, which I personally find convenient (e.g. for accessing release notes).