### PR TITLE
chore: add/fix meta data used by npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,17 @@
   "description": "Node.js stateless session utility using signed and encrypted cookies to store data. Works with Next.js, Express, NestJs, Fastify, and any Node.js HTTP framework.",
   "license": "MIT",
   "author": "Vincent Voyer <vincent@codeagain.com>",
-  "repository": "github:vvo/iron-session",
+  "repository": "https://github.com/vvo/iron-session.git",
+  "bugs": {
+    "url": "https://github.com/vvo/iron-session/issues"
+  },
+  "keywords": [
+    "Login",
+    "Auth",
+    "Next.js",
+    "Express",
+    "NestJs"
+  ],  
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
When you search for this repository online, the first hit is its [npm](https://www.npmjs.com/package/iron-session), where no github data is shown (Repository, issues). This means you have to search again to get to the the repo's Github page.

## Current

![image](https://user-images.githubusercontent.com/880132/144140023-bceb7a69-6618-49ed-ad11-4bca17e479fb.png)
 
## Possible

![image](https://user-images.githubusercontent.com/880132/144140074-e5660df2-b9dc-4380-b5b6-bfe1a2d7ad52.png)

Also added keywords for people searching on npm.