### PR TITLE
fix(examples): unnecessary fetch of user after login

### DIFF
--- a/examples/next.js-typescript/pages/login.tsx
+++ b/examples/next.js-typescript/pages/login.tsx
@@ -32,6 +32,7 @@ export default function Login() {
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify(body),
                 }),
+                false,
               );
             } catch (error) {
               if (error instanceof FetchError) {

--- a/examples/next.js/pages/login.js
+++ b/examples/next.js/pages/login.js
@@ -32,6 +32,7 @@ export default function Login() {
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify(body),
                 }),
+                false,
               );
             } catch (error) {
               if (error instanceof FetchError) {


### PR DESCRIPTION
The login endpoint returns anyhow what the user endpoint does, so disable SWR revalidation after mutate.