### PR TITLE
Support response type for NextJS

### DIFF
--- a/next/index.ts
+++ b/next/index.ts
@@ -7,10 +7,10 @@ import type { IronSessionOptions } from "iron-session";
 import { getIronSession } from "iron-session";
 import getPropertyDescriptorForReqSession from "../src/getPropertyDescriptorForReqSession";
 
-export function withIronSessionApiRoute(
-  handler: NextApiHandler,
+export function withIronSessionApiRoute<ResponseType>(
+  handler: NextApiHandler<ResponseType>,
   options: IronSessionOptions,
-): NextApiHandler {
+): NextApiHandler<ResponseType> {
   return async function nextApiHandlerWrappedWithIronSession(req, res) {
     const session = await getIronSession(req, res, options);
 


### PR DESCRIPTION
```ts
export default withIronSessionApiRoute<string[]>(async (request, response) => {
  response.json([NaN, 1, 2]); // We need error here
  response.json(['this', 'is', 'ok']);
}, ironSessionConfig);

```