### PR TITLE
FIX: Fix to tsconfig to add in required baseUrl key. Change imports/exports in a few files to make using baseUrl in other projects work.

### DIFF
--- a/express/index.ts
+++ b/express/index.ts
@@ -1,7 +1,7 @@
 import type { IronSessionOptions } from "iron-session";
 import { getIronSession } from "iron-session";
-import type { Request, Response, NextFunction } from "express";
-import getPropertyDescriptorForReqSession from "../src/getPropertyDescriptorForReqSession";
+import type { Request, Response, NextFunction } from "express/ts4.0";
+import { getPropertyDescriptorForReqSession } from "iron-session";
 
 export function ironSession(
   sessionOptions: IronSessionOptions,

--- a/next/index.ts
+++ b/next/index.ts
@@ -2,10 +2,9 @@ import type {
   NextApiHandler,
   GetServerSidePropsContext,
   GetServerSidePropsResult,
-} from "next";
+} from "next/types";
 import type { IronSessionOptions } from "iron-session";
-import { getIronSession } from "iron-session";
-import getPropertyDescriptorForReqSession from "../src/getPropertyDescriptorForReqSession";
+import { getIronSession, getPropertyDescriptorForReqSession } from "iron-session";
 
 export function withIronSessionApiRoute(
   handler: NextApiHandler,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-session",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Node.js stateless session utility using signed and encrypted cookies to store data. Works with Next.js, Express, NestJs, Fastify, and any Node.js HTTP framework.",
   "keywords": [
     "Next.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -317,3 +317,5 @@ export async function sealData(
 function normalizeStringPasswordToMap(password: password) {
   return typeof password === "string" ? { 1: password } : password;
 }
+
+export { default as getPropertyDescriptorForReqSession } from "./getPropertyDescriptorForReqSession";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "next"],
   "exclude": ["node_modules", "./**/dist"],
   "compilerOptions": {
+    "baseUrl": "./",
     "paths": {
       "iron-session": ["./src/index.ts"],
       "iron-session/next": ["./next/index.ts"],


### PR DESCRIPTION
It mentions here in the Typescript docs that this baseUrl is required.
https://www.typescriptlang.org/tsconfig#paths

I added this in and made a few changes to some of the imports/exports of a few files to make sure that in projects using a baseURL and paths everything works correctly.

This is the original issue with more info on the error I had that made me check this out.
https://github.com/vvo/iron-session/issues/455

Fantastic project! We've been using it and I'm really digging it.

Hopefully this change is helpful. 

All tests still passed.