### PR TITLE
feat(next): Add ability to dynamically compute iron options based on req, res

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Only two options are required: `password` and `cookieName`. Everything else is a
 }
 ```
 
-### Next.js: withIronSessionApiRoute(handler, ironOptions | (req, res) => IronSessionOptions | Promise\<IronSessionOptions\>)
+### Next.js: withIronSessionApiRoute(handler, ironOptions | (req: NextApiRequest, res: NextApiResponse) => IronSessionOptions | Promise\<IronSessionOptions\>)
 
 Wraps a [Next.js API Route](https://nextjs.org/docs/api-routes/dynamic-api-routes) and adds a `session` object to the request.
 
@@ -629,7 +629,7 @@ export default withIronSessionApiRoute(
 );
 ```
 
-### Next.js: withIronSessionSsr(handler, ironOptions | (req, res) => IronSessionOptions | Promise\<IronSessionOptions\>)
+### Next.js: withIronSessionSsr(handler, ironOptions | (req: IncomingMessage, res: ServerResponse) => IronSessionOptions | Promise\<IronSessionOptions\>)
 
 Wraps a [Next.js getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) and adds a `session` object to the request of the context.
 

--- a/README.md
+++ b/README.md
@@ -420,17 +420,17 @@ export default async function sendEmailRoute(req, res) {
 The default `ttl` for such seals is 14 days. To specify a `ttl`, provide it in seconds like so:
 
 ```ts
-  const fifteenMinutesInSeconds = 15 * 60;
-  
-  const seal = await sealData(
-    {
-      userId: user.id,
-    },
-    {
-      password: "complex_password_at_least_32_characters_long",
-      ttl: fifteenMinutesInSeconds,
-    },
-  );
+const fifteenMinutesInSeconds = 15 * 60;
+
+const seal = await sealData(
+  {
+    userId: user.id,
+  },
+  {
+    password: "complex_password_at_least_32_characters_long",
+    ttl: fifteenMinutesInSeconds,
+  },
+);
 ```
 
 **Login the user automatically and redirect:**
@@ -586,7 +586,7 @@ Only two options are required: `password` and `cookieName`. Everything else is a
 }
 ```
 
-### Next.js: withIronSessionApiRoute(handler, ironOptions)
+### Next.js: withIronSessionApiRoute(handler, ironOptions | (req, res) => IronSessionOptions | Promise\<IronSessionOptions\>)
 
 Wraps a [Next.js API Route](https://nextjs.org/docs/api-routes/dynamic-api-routes) and adds a `session` object to the request.
 
@@ -606,9 +606,30 @@ export default withIronSessionApiRoute(
     },
   },
 );
+
+// You can also pass an async or sync function which takes request and response object and return IronSessionOptions
+export default withIronSessionApiRoute(
+  function userRoute(req, res) {
+    res.send({ user: req.session.user });
+  },
+  (req, res) => {
+    // Infer max cookie from request
+    const maxCookieAge = getMaxCookieAge(req);
+    return {
+      cookieName: "myapp_cookiename",
+      password: "complex_password_at_least_32_characters_long",
+      // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
+      cookieOptions: {
+        // setMaxCookie age here.
+        maxCookieAge,
+        secure: process.env.NODE_ENV === "production",
+      },
+    };
+  },
+);
 ```
 
-### Next.js: withIronSessionSsr(handler, ironOptions)
+### Next.js: withIronSessionSsr(handler, ironOptions | (req, res) => IronSessionOptions | Promise\<IronSessionOptions\>)
 
 Wraps a [Next.js getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) and adds a `session` object to the request of the context.
 
@@ -630,6 +651,27 @@ export const getServerSideProps = withIronSessionSsr(
     cookieOptions: {
       secure: process.env.NODE_ENV === "production",
     },
+  },
+);
+
+// You can also pass an async or sync function which takes request and response object and return IronSessionOptions
+export const getServerSideProps = withIronSessionSsr(
+  async function getServerSideProps({ req }) {
+    return {
+      props: {
+        user: req.session.user,
+      },
+    };
+  },
+  (req, res) => {
+    return {
+      cookieName: "myapp_cookiename",
+      password: "complex_password_at_least_32_characters_long",
+      // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
+      cookieOptions: {
+        secure: process.env.NODE_ENV === "production",
+      },
+    };
   },
 );
 ```

--- a/next/index.ts
+++ b/next/index.ts
@@ -2,21 +2,23 @@ import type {
   NextApiHandler,
   GetServerSidePropsContext,
   GetServerSidePropsResult,
+  NextApiRequest,
+  NextApiResponse,
 } from "next";
 import type { IronSessionOptions } from "iron-session";
 import { getIronSession } from "iron-session";
 import getPropertyDescriptorForReqSession from "../src/getPropertyDescriptorForReqSession";
-import type { IncomingMessage, ServerResponse } from "http";
+import { IncomingMessage, ServerResponse } from "http";
 
 // Argument types based on getIronSession function
-type GetIronSessionOptions = (
-  request: IncomingMessage,
-  response: ServerResponse,
-) => Promise<IronSessionOptions>;
+type GetIronSessionApiOptions = (
+  request: NextApiRequest,
+  response: NextApiResponse,
+) => Promise<IronSessionOptions> | IronSessionOptions;
 
 export function withIronSessionApiRoute(
   handler: NextApiHandler,
-  options: IronSessionOptions | GetIronSessionOptions,
+  options: IronSessionOptions | GetIronSessionApiOptions,
 ): NextApiHandler {
   return async function nextApiHandlerWrappedWithIronSession(req, res) {
     // If options is a function, call it and assign the results back.
@@ -38,13 +40,18 @@ export function withIronSessionApiRoute(
   };
 }
 
+type GetIronSessionSSROptions = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => Promise<IronSessionOptions> | IronSessionOptions;
+
 export function withIronSessionSsr<
   P extends { [key: string]: unknown } = { [key: string]: unknown },
 >(
   handler: (
     context: GetServerSidePropsContext,
   ) => GetServerSidePropsResult<P> | Promise<GetServerSidePropsResult<P>>,
-  options: IronSessionOptions | GetIronSessionOptions,
+  options: IronSessionOptions | GetIronSessionSSROptions,
 ) {
   return async function nextGetServerSidePropsHandlerWrappedWithIronSession(
     context: GetServerSidePropsContext,

--- a/next/index.ts
+++ b/next/index.ts
@@ -6,12 +6,23 @@ import type {
 import type { IronSessionOptions } from "iron-session";
 import { getIronSession } from "iron-session";
 import getPropertyDescriptorForReqSession from "../src/getPropertyDescriptorForReqSession";
+import type { IncomingMessage, ServerResponse } from "http";
+
+// Argument types based on getIronSession function
+type GetIronSessionOptions = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => Promise<IronSessionOptions>;
 
 export function withIronSessionApiRoute(
   handler: NextApiHandler,
-  options: IronSessionOptions,
+  options: IronSessionOptions | GetIronSessionOptions,
 ): NextApiHandler {
   return async function nextApiHandlerWrappedWithIronSession(req, res) {
+    // If options is a function, call it and assign the results back.
+    if (options instanceof Function) {
+      options = await options(req, res);
+    }
     const session = await getIronSession(req, res, options);
 
     // we define req.session as being enumerable (so console.log(req) shows it)
@@ -33,11 +44,15 @@ export function withIronSessionSsr<
   handler: (
     context: GetServerSidePropsContext,
   ) => GetServerSidePropsResult<P> | Promise<GetServerSidePropsResult<P>>,
-  options: IronSessionOptions,
+  options: IronSessionOptions | GetIronSessionOptions,
 ) {
   return async function nextGetServerSidePropsHandlerWrappedWithIronSession(
     context: GetServerSidePropsContext,
   ) {
+    // If options is a function, call it and assign the results back.
+    if (options instanceof Function) {
+      options = await options(context.req, context.res);
+    }
     const session = await getIronSession(context.req, context.res, options);
     Object.defineProperty(
       context.req,

--- a/next/index.ts
+++ b/next/index.ts
@@ -40,6 +40,7 @@ export function withIronSessionApiRoute(
   };
 }
 
+// Argument type based on the SSR context
 type GetIronSessionSSROptions = (
   request: IncomingMessage,
   response: ServerResponse,


### PR DESCRIPTION
This adds ability to pass options built using request or response object. 

This will resolve the issues people have in https://github.com/vvo/iron-session/issues/410

@vvo mentioned making maxCookieAge or cookieName functions but that approach will require changing the signature of the underlying cookie type which is coming from another package. It is also not very flexible and will require bigger changes. 

That's why I'm going with current approach where you can pass a function which returns option object and use request or response props in it. 

I'm happy to make any changes. Let me know. 