### PR TITLE
Add note for redirects and sameSite cookie options

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,8 @@ async function magicLoginRoute(req, res) {
 
 You might want to include error handling in the API routes. For example checking if `req.session.user` is already defined in login or handling bad seals.
 
+Please note that if you redirect based on an incoming request that is not the same origin as your server then the cookie may not be set if your cookie options do not have the `sameSite: 'none'` option enabled.
+
 ### Impersonation, login as someone else
 
 You may want to impersonate your own users, to check how they see your application. This can be extremely useful. For example you could have a page that list all your users and with links you can click to impersonate them.


### PR DESCRIPTION
Updating the section of the readme where it mentions redirects because there is a catch. If a user tries to copy the example given - it may not work right away if they don't set a `sameSite: 'none'` option on their cookies, especially for incoming requests that originated from different origins, which is the case for things like clicking links from emails or auth redirects from different auth providers