### PR TITLE
docs: correct next.js middleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ export const middleware = async (req: NextRequest) => {
 
   // demo:
   if (user?.admin !== "true") {
-    return new NextResponse(null, { status: 403 }); // unauthorized to see pages inside admin/
+    // unauthorized to see pages inside admin/
+    return NextResponse.redirect(new URL('/unauthorized', req.url)) // redirect to /unauthorized page
   }
 
   return res;


### PR DESCRIPTION
To respect the differences in client-side and server-side navigation, and to help ensure that developers do not build insecure Middleware, Middleware can no longer produce a response body. This ensures that Middleware is only used to rewrite, redirect, or modify the incoming request (e.g. setting cookies).