### PR TITLE
fix: check if the headers object has append function

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -225,7 +225,7 @@ export function createGetIronSession(
 }
 
 function addToCookies(cookieValue: string, res: ResponseType) {
-  if ("headers" in res) {
+  if ("headers" in res && "append" in res.headers) {
     res.headers.append("set-cookie", cookieValue);
     return;
   }


### PR DESCRIPTION
There is an issue when deploying a nextjs 12 app into AWS infrastructure. 

When calling a nextjs api route the response.headers does not have the "append" method.

This PR proposes a fix that adds a check to the response headers in the addToCookie  function the exists in the iron-session _/core.ts file_.