### PR TITLE
update README.md to remove reference to /edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Since there's no pre-available `res` object in Next.js's middlewares, you need t
 // /middleware.ts
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { getIronSession } from "iron-session/edge";
+import { getIronSession } from "iron-session";
 
 export const middleware = async (req: NextRequest) => {
   const res = NextResponse.next();


### PR DESCRIPTION
the "getIronSession" seems to work for me when I remove the /edge from the import. Using the /edge resulted in an error that says. " Error: no native implementation of WebCrypto is available in current context at getCrypto". Just thought this might be a good upgrade to the documentation to help new users. Thank you so much for your work on this library!