### PR TITLE
chore: fix readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import { cookies } from 'next/headers';
 import { getIronSession } from 'iron-session';
 
 async function getIronSessionData() {
-  const session = await getIronSession(cookies(), { password: "...", cookieName: "..." });
+  return await getIronSession(cookies(), { password: "...", cookieName: "..." });
 }
 
 function Profile() {


### PR DESCRIPTION
the `getSessionData()` function assigns the session data to the `session` variable, but doesn't return anything, making the example incorrect.