### PR TITLE
Make properties in T for IronSession<T> optional

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -98,7 +98,7 @@ export interface SessionOptions {
   cookieOptions?: CookieOptions;
 }
 
-export type IronSession<T> = T & {
+export type IronSession<T> = Partial<T> & {
   /**
    * Encrypts the session data and sets the cookie.
    */


### PR DESCRIPTION
Resolves #661 

I noticed places where stuff gets cast `as T` internally (e.g. [here](https://github.com/vvo/iron-session/blob/912ae95c4d98ba0220c71601527eb37fc80e9d75/src/core.ts#L370)), this is inaccurate but otherwise harmless for external API so I won't mess with it.