### PR TITLE
removed dead code, unsealData doesn't need ttl param

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The session data is stored in signed and encrypted cookies which are decoded by 
   - [`session.destroy(): void`](#sessiondestroy-void)
   - [`session.updateConfig(sessionOptions: SessionOptions): void`](#sessionupdateconfigsessionoptions-sessionoptions-void)
   - [`sealData(data: unknown, { password, ttl }): Promise<string>`](#sealdatadata-unknown--password-ttl--promisestring)
-  - [`unsealData<T>(seal: string, { password, ttl }): Promise<T>`](#unsealdatatseal-string--password-ttl--promiset)
+  - [`unsealData<T>(seal: string, { password }): Promise<T>`](#unsealdatatseal-string--password--promiset)
 - [FAQ](#faq)
   - [Why use pure cookies for sessions?](#why-use-pure-cookies-for-sessions)
   - [How to invalidate sessions?](#how-to-invalidate-sessions)
@@ -188,7 +188,7 @@ Updates the configuration of the session with new session options. You still nee
 
 This is the underlying method and seal mechanism that powers `iron-session`. You can use it to seal any `data` you want and pass it around. One usecase are magic links: you generate a seal that contains a user id to login and send it to a route on your website (like `/magic-login`). Once received, you can safely decode the seal with `unsealData` and log the user in.
 
-### `unsealData<T>(seal: string, { password, ttl }): Promise<T>`
+### `unsealData<T>(seal: string, { password }): Promise<T>`
 
 This is the opposite of `sealData` and allow you to decode a seal to get the original data back.
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -229,10 +229,7 @@ export function createSealData(_crypto: Crypto) {
 export function createUnsealData(_crypto: Crypto) {
   return async function unsealData<T>(
     seal: string,
-    {
-      password,
-      ttl = fourteenDaysInSeconds,
-    }: { password: Password; ttl?: number },
+    { password }: { password: Password },
   ): Promise<T> {
     const passwordsMap = normalizeStringPasswordToMap(password);
     const { sealWithoutVersion, tokenVersion } = parseSeal(seal);
@@ -241,7 +238,6 @@ export function createUnsealData(_crypto: Crypto) {
       const data =
         (await ironUnseal(_crypto, sealWithoutVersion, passwordsMap, {
           ...ironDefaults,
-          ttl: ttl * 1000,
         })) ?? {};
 
       if (tokenVersion === 2) {
@@ -365,7 +361,6 @@ export function createGetIronSession(
     const session = sealFromCookies
       ? await unsealData<T>(sealFromCookies, {
           password: passwordsMap,
-          ttl: sessionConfig.ttl,
         })
       : ({} as T);
 
@@ -452,7 +447,6 @@ async function getIronSessionFromCookieStore<T extends object>(
   const session = sealFromCookies
     ? await unsealData<T>(sealFromCookies, {
         password: passwordsMap,
-        ttl: sessionConfig.ttl,
       })
     : ({} as T);
 


### PR DESCRIPTION
Looking at the dependency, unseal doesn't use the ttl param, so setting the ttl in unsealData is dead code. I can't imagine how it would be useful either, given that expiry information is already stored in the encrypted data.