### PR TITLE
[W.I.P] Adding Post Quantum Encryption to the lib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 coverage*
 *.tsbuildinfo
 .turbo
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 The session data is stored in signed and encrypted cookies which are decoded by your server code in a stateless fashion (= no network involved). This is the same technique used by frameworks like
 [Ruby On Rails](https://guides.rubyonrails.org/security.html#session-storage).
 
+**New in v8.1**: Post-quantum cryptography support to protect against future quantum computing attacks.
+
 <p align="center"><i>Online demo and examples: <a href="https://get-iron-session.vercel.app/">https://get-iron-session.vercel.app</a></i> 👀 <br/>
  <i>Featured in the <a href="https://nextjs.org/docs/authentication">Next.js documentation</a></i> ⭐️</p>
 
@@ -37,6 +39,7 @@ The session data is stored in signed and encrypted cookies which are decoded by 
 - [Examples](#examples)
 - [Project status](#project-status)
 - [Session options](#session-options)
+- [Post-Quantum Cryptography](#post-quantum-cryptography)
 - [API](#api)
   - [`getIronSession<T>(req, res, sessionOptions): Promise<IronSession<T>>`](#getironsessiontreq-res-sessionoptions-promiseironsessiont)
   - [`getIronSession<T>(cookieStore, sessionOptions): Promise<IronSession<T>>`](#getironsessiontcookiestore-sessionoptions-promiseironsessiont)
@@ -130,6 +133,7 @@ Two options are required: `password` and `cookieName`. Everything else is automa
 - `password`, **required**: Private key used to encrypt the cookie. It has to be at least 32 characters long. Use <https://1password.com/password-generator/> to generate strong passwords. `password` can be either a `string` or an `object` with incrementing keys like this: `{2: "...", 1: "..."}` to allow for password rotation.  iron-session will use the highest numbered key for new cookies.
 - `cookieName`, **required**: Name of the cookie to be stored
 - `ttl`, _optional_: In seconds. Default to the equivalent of 14 days. You can set this to `0` and iron-session will compute the maximum allowed value by cookies.
+- `usePostQuantum`, _optional_: Boolean flag to enable post-quantum encryption. Default is `false`. When enabled, uses ML-KEM1024 for key exchange instead of the traditional encryption. See [Post-Quantum Cryptography](#post-quantum-cryptography) for more details.
 - `cookieOptions`, _optional_: Any option available from [jshttp/cookie#serialize](https://github.com/jshttp/cookie#cookieserializename-value-options) except for `encode` which is not a Set-Cookie Attribute. See [Mozilla Set-Cookie Attributes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) and [Chrome Cookie Fields](https://developer.chrome.com/docs/devtools/application/cookies/#fields). Default to:
 
   ```js
@@ -141,6 +145,37 @@ Two options are required: `password` and `cookieName`. Everything else is automa
     path: "/",
   }
   ```
+
+## Post-Quantum Cryptography
+
+Iron-session now supports post-quantum cryptography to protect your session data against future quantum computing attacks. This feature is opt-in and can be enabled by setting `usePostQuantum: true` in your session options.
+
+```ts
+// Enable post-quantum encryption
+const session = await getIronSession(req, res, {
+  password: "your-password-at-least-32-characters-long",
+  cookieName: "your-cookie-name",
+  usePostQuantum: true
+});
+```
+
+### How it works
+
+When post-quantum encryption is enabled:
+
+1. The session uses ML-KEM1024 (formerly Kyber-1024), a NIST-approved post-quantum key encapsulation mechanism
+2. This provides 256-bit security that's resistant to attacks from quantum computers
+3. The implementation maintains AES-GCM for symmetric encryption after secure key exchange
+
+### When to use it
+
+Post-quantum cryptography is recommended if:
+
+- You need long-term security for sensitive session data
+- You want to future-proof your application against quantum computing advances
+- You're handling particularly sensitive information that requires the highest level of cryptographic protection
+
+The feature has a minimal performance impact and provides a significant security improvement for forward-looking applications.
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -1,79 +1,76 @@
 {
-  "name": "iron-session",
-  "version": "8.0.4",
-  "description": "Secure, stateless, and cookie-based session library for JavaScript",
-  "keywords": [
-    "session",
-    "secure",
-    "stateless",
-    "cookie",
-    "encryption",
-    "security",
-    "next.js",
-    "node.js"
-  ],
-  "bugs": "https://github.com/vvo/iron-session/issues",
-  "repository": "github:vvo/iron-session",
-  "funding": [
-    "https://github.com/sponsors/vvo",
-    "https://github.com/sponsors/brc-dd"
-  ],
-  "license": "MIT",
-  "author": "Vincent Voyer <vincent@codeagain.com> (https://github.com/vvo)",
-  "sideEffects": false,
-  "type": "module",
-  "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
-  },
-  "main": "./dist/index.cjs",
-  "files": [
-    "dist/*"
-  ],
-  "scripts": {
-    "build": "tsup",
-    "dev": "pnpm build && concurrently \"pnpm build --watch\" \"pnpm --filter=next-example dev\" ",
-    "lint": "tsc --noEmit && tsc --noEmit -p examples/next/tsconfig.json && pnpm eslint . && publint",
-    "prepare": "pnpm build && tsc --noEmit",
-    "start": "turbo start --filter=next-example",
-    "test": "c8 -r text -r lcov node --import tsx --test src/*.test.ts && pnpm build",
-    "test:watch": "node --import tsx --test --watch src/*.test.ts"
-  },
-  "prettier": {
-    "plugins": [
-      "prettier-plugin-packagejson"
-    ],
-    "trailingComma": "all"
-  },
-  "dependencies": {
-    "cookie": "^0.7.2",
-    "iron-webcrypto": "^1.2.1",
-    "uncrypto": "^0.1.3"
-  },
-  "devDependencies": {
-    "@types/cookie": "0.6.0",
-    "@types/node": "20.17.24",
-    "@typescript-eslint/eslint-plugin": "7.18.0",
-    "@typescript-eslint/parser": "7.18.0",
-    "c8": "10.1.3",
-    "concurrently": "8.2.2",
-    "eslint": "8.57.1",
-    "eslint-config-prettier": "9.1.0",
-    "eslint-import-resolver-node": "0.3.9",
-    "eslint-import-resolver-typescript": "3.9.1",
-    "eslint-plugin-import": "2.31.0",
-    "eslint-plugin-prettier": "5.2.5",
-    "prettier": "3.5.3",
-    "prettier-plugin-packagejson": "2.5.10",
-    "publint": "0.3.9",
-    "tsup": "8.4.0",
-    "tsx": "4.19.3",
-    "turbo": "^2.0.5",
-    "typescript": "5.8.2"
-  },
-  "packageManager": "pnpm@9.6.0",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  }
+	"name": "iron-session",
+	"version": "8.0.4",
+	"description": "Secure, stateless, and cookie-based session library for JavaScript",
+	"keywords": [
+		"session",
+		"secure",
+		"stateless",
+		"cookie",
+		"encryption",
+		"security",
+		"next.js",
+		"node.js"
+	],
+	"bugs": "https://github.com/vvo/iron-session/issues",
+	"repository": "github:vvo/iron-session",
+	"funding": [
+		"https://github.com/sponsors/vvo",
+		"https://github.com/sponsors/brc-dd"
+	],
+	"license": "MIT",
+	"author": "Vincent Voyer <vincent@codeagain.com> (https://github.com/vvo)",
+	"sideEffects": false,
+	"type": "module",
+	"exports": {
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs"
+	},
+	"main": "./dist/index.cjs",
+	"files": ["dist/*"],
+	"scripts": {
+		"build": "tsup",
+		"dev": "pnpm build && concurrently \"pnpm build --watch\" \"pnpm --filter=next-example dev\" ",
+		"lint": "tsc --noEmit && tsc --noEmit -p examples/next/tsconfig.json && pnpm eslint . && publint",
+		"prepare": "pnpm build && tsc --noEmit",
+		"start": "turbo start --filter=next-example",
+		"test": "c8 -r text -r lcov node --import tsx --test src/*.test.ts && pnpm build",
+		"test:watch": "node --import tsx --test --watch src/*.test.ts"
+	},
+	"prettier": {
+		"plugins": ["prettier-plugin-packagejson"],
+		"trailingComma": "all"
+	},
+	"dependencies": {
+		"@noble/hashes": "^1.7.1",
+		"@noble/post-quantum": "^0.4.0",
+		"cookie": "^0.7.2",
+		"uncrypto": "^0.1.3"
+	},
+	"devDependencies": {
+		"@types/cookie": "0.6.0",
+		"@types/node": "20.17.24",
+		"@typescript-eslint/eslint-plugin": "7.18.0",
+		"@typescript-eslint/parser": "7.18.0",
+		"c8": "10.1.3",
+		"concurrently": "8.2.2",
+		"eslint": "8.57.1",
+		"eslint-config-prettier": "9.1.0",
+		"eslint-import-resolver-node": "0.3.9",
+		"eslint-import-resolver-typescript": "3.9.1",
+		"eslint-plugin-import": "2.31.0",
+		"eslint-plugin-prettier": "5.2.5",
+		"prettier": "3.5.3",
+		"prettier-plugin-packagejson": "2.5.10",
+		"publint": "0.3.9",
+		"tsup": "8.4.0",
+		"tsx": "4.19.3",
+		"turbo": "^2.5.0",
+		"typescript": "5.8.3"
+	},
+	"packageManager": "pnpm@9.6.0",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
 		"require": "./dist/index.cjs"
 	},
 	"main": "./dist/index.cjs",
-	"files": ["dist/*"],
+	"files": [
+		"dist/*"
+	],
 	"scripts": {
 		"build": "tsup",
 		"dev": "pnpm build && concurrently \"pnpm build --watch\" \"pnpm --filter=next-example dev\" ",
@@ -38,13 +40,18 @@
 		"test:watch": "node --import tsx --test --watch src/*.test.ts"
 	},
 	"prettier": {
-		"plugins": ["prettier-plugin-packagejson"],
+		"plugins": [
+			"prettier-plugin-packagejson"
+		],
 		"trailingComma": "all"
 	},
 	"dependencies": {
 		"@noble/hashes": "^1.7.1",
 		"@noble/post-quantum": "^0.4.0",
 		"cookie": "^0.7.2",
+		"http": "^0.0.1-security",
+		"iron-webcrypto": "^1.2.1",
+		"rfc4648": "^1.5.4",
 		"uncrypto": "^0.1.3"
 	},
 	"devDependencies": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,31 +1,37 @@
-import type { IncomingMessage, ServerResponse } from "http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { parse, serialize, type CookieSerializeOptions } from "cookie";
-import {
-  defaults as ironDefaults,
-  seal as ironSeal,
-  unseal as ironUnseal,
-} from "iron-webcrypto";
+import { ml_kem1024 } from "@noble/post-quantum/ml-kem";
+import { ml_dsa87 } from "@noble/post-quantum/ml-dsa";
+import { randomBytes } from "@noble/hashes/utils";
+import { base64url } from "rfc4648";
 
 type PasswordsMap = Record<string, string>;
 type Password = PasswordsMap | string;
 type RequestType = IncomingMessage | Request;
 type ResponseType = Response | ServerResponse;
 
+interface PQSealResult {
+	ciphertext: string;
+	publicKey: string;
+	signature: string;
+	signPublicKey: string;
+}
+
 /**
  * {@link https://wicg.github.io/cookie-store/#dictdef-cookielistitem CookieListItem}
  * as specified by W3C.
  */
 interface CookieListItem
-  extends Pick<
-    CookieSerializeOptions,
-    "domain" | "path" | "sameSite" | "secure"
-  > {
-  /** A string with the name of a cookie. */
-  name: string;
-  /** A string containing the value of the cookie. */
-  value: string;
-  /** A number of milliseconds or Date interface containing the expires of the cookie. */
-  expires?: CookieSerializeOptions["expires"] | number;
+	extends Pick<
+		CookieSerializeOptions,
+		"domain" | "path" | "sameSite" | "secure"
+	> {
+	/** A string with the name of a cookie. */
+	name: string;
+	/** A string containing the value of the cookie. */
+	value: string;
+	/** A number of milliseconds or Date interface containing the expires of the cookie. */
+	expires?: CookieSerializeOptions["expires"] | number;
 }
 
 /**
@@ -33,18 +39,18 @@ interface CookieListItem
  * the `httpOnly`, `maxAge` and `priority` properties.
  */
 type ResponseCookie = CookieListItem &
-  Pick<CookieSerializeOptions, "httpOnly" | "maxAge" | "priority">;
+	Pick<CookieSerializeOptions, "httpOnly" | "maxAge" | "priority">;
 
 /**
  * The high-level type definition of the .get() and .set() methods
  * of { cookies() } from "next/headers"
  */
 export interface CookieStore {
-  get: (name: string) => { name: string; value: string } | undefined;
-  set: {
-    (name: string, value: string, cookie?: Partial<ResponseCookie>): void;
-    (options: ResponseCookie): void;
-  };
+	get: (name: string) => { name: string; value: string } | undefined;
+	set: {
+		(name: string, value: string, cookie?: Partial<ResponseCookie>): void;
+		(options: ResponseCookie): void;
+	};
 }
 
 /**
@@ -56,63 +62,63 @@ export interface CookieStore {
 type CookieOptions = Omit<CookieSerializeOptions, "encode">;
 
 export interface SessionOptions {
-  /**
-   * The cookie name that will be used inside the browser. Make sure it's unique
-   * given your application.
-   *
-   * @example 'vercel-session'
-   */
-  cookieName: string;
+	/**
+	 * The cookie name that will be used inside the browser. Make sure it's unique
+	 * given your application.
+	 *
+	 * @example 'vercel-session'
+	 */
+	cookieName: string;
 
-  /**
-   * The password(s) that will be used to encrypt the cookie. Can either be a string
-   * or an object.
-   *
-   * When you provide multiple passwords then all of them will be used to decrypt
-   * the cookie. But only the most recent (`= highest key`, `2` in the example)
-   * password will be used to encrypt the cookie. This allows password rotation.
-   *
-   * @example { 1: 'password-1', 2: 'password-2' }
-   */
-  password: Password;
+	/**
+	 * The password(s) that will be used to encrypt the cookie. Can either be a string
+	 * or an object.
+	 *
+	 * When you provide multiple passwords then all of them will be used to decrypt
+	 * the cookie. But only the most recent (`= highest key`, `2` in the example)
+	 * password will be used to encrypt the cookie. This allows password rotation.
+	 *
+	 * @example { 1: 'password-1', 2: 'password-2' }
+	 */
+	password: Password;
 
-  /**
-   * The time (in seconds) that the session will be valid for. Also sets the
-   * `max-age` attribute of the cookie automatically (`= ttl - 60s`, so that the
-   * cookie always expire before the session).
-   *
-   * `ttl = 0` means no expiration.
-   *
-   * @default 1209600
-   */
-  ttl?: number;
+	/**
+	 * The time (in seconds) that the session will be valid for. Also sets the
+	 * `max-age` attribute of the cookie automatically (`= ttl - 60s`, so that the
+	 * cookie always expire before the session).
+	 *
+	 * `ttl = 0` means no expiration.
+	 *
+	 * @default 1209600
+	 */
+	ttl?: number;
 
-  /**
-   * The options that will be passed to the cookie library.
-   *
-   * If you want to use "session cookies" (cookies that are deleted when the browser
-   * is closed) then you need to pass `cookieOptions: { maxAge: undefined }`
-   *
-   * @see https://github.com/jshttp/cookie#options-1
-   */
-  cookieOptions?: CookieOptions;
+	/**
+	 * The options that will be passed to the cookie library.
+	 *
+	 * If you want to use "session cookies" (cookies that are deleted when the browser
+	 * is closed) then you need to pass `cookieOptions: { maxAge: undefined }`
+	 *
+	 * @see https://github.com/jshttp/cookie#options-1
+	 */
+	cookieOptions?: CookieOptions;
 }
 
 export type IronSession<T> = T & {
-  /**
-   * Encrypts the session data and sets the cookie.
-   */
-  readonly save: () => Promise<void>;
+	/**
+	 * Encrypts the session data and sets the cookie.
+	 */
+	readonly save: () => Promise<void>;
 
-  /**
-   * Destroys the session data and removes the cookie.
-   */
-  readonly destroy: () => void;
+	/**
+	 * Destroys the session data and removes the cookie.
+	 */
+	readonly destroy: () => void;
 
-  /**
-   * Update the session configuration. You still need to call save() to send the new cookie.
-   */
-  readonly updateConfig: (newSessionOptions: SessionOptions) => void;
+	/**
+	 * Update the session configuration. You still need to call save() to send the new cookie.
+	 */
+	readonly updateConfig: (newSessionOptions: SessionOptions) => void;
 };
 
 // default time allowed to check for iron seal validity when ttl passed
@@ -126,379 +132,434 @@ const currentMajorVersion = 2;
 const versionDelimiter = "~";
 
 const defaultOptions: Required<Pick<SessionOptions, "ttl" | "cookieOptions">> =
-  {
-    ttl: fourteenDaysInSeconds,
-    cookieOptions: { httpOnly: true, secure: true, sameSite: "lax", path: "/" },
-  };
+	{
+		ttl: fourteenDaysInSeconds,
+		cookieOptions: { httpOnly: true, secure: true, sameSite: "lax", path: "/" },
+	};
 
 function normalizeStringPasswordToMap(password: Password): PasswordsMap {
-  return typeof password === "string" ? { 1: password } : password;
+	return typeof password === "string" ? { 1: password } : password;
 }
 
 function parseSeal(seal: string): {
-  sealWithoutVersion: string;
-  tokenVersion: number | null;
+	sealWithoutVersion: string;
+	tokenVersion: number | null;
 } {
-  const [sealWithoutVersion, tokenVersionAsString] =
-    seal.split(versionDelimiter);
-  const tokenVersion =
-    tokenVersionAsString == null ? null : parseInt(tokenVersionAsString, 10);
+	const [sealWithoutVersion, tokenVersionAsString] =
+		seal.split(versionDelimiter);
+	const tokenVersion =
+		tokenVersionAsString == null
+			? null
+			: Number.parseInt(tokenVersionAsString, 10);
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return { sealWithoutVersion: sealWithoutVersion!, tokenVersion };
+	// Handle the case where sealWithoutVersion could be undefined
+	if (sealWithoutVersion === undefined) {
+		throw new Error("Invalid seal format: missing seal data");
+	}
+
+	return { sealWithoutVersion, tokenVersion };
 }
 
 function computeCookieMaxAge(ttl: number): number {
-  if (ttl === 0) {
-    // ttl = 0 means no expiration
-    // but in reality cookies have to expire (can't have no max-age)
-    // 2147483647 is the max value for max-age in cookies
-    // see https://stackoverflow.com/a/11685301/147079
-    return 2147483647;
-  }
+	if (ttl === 0) {
+		// ttl = 0 means no expiration
+		// but in reality cookies have to expire (can't have no max-age)
+		// 2147483647 is the max value for max-age in cookies
+		// see https://stackoverflow.com/a/11685301/147079
+		return 2147483647;
+	}
 
-  // The next line makes sure browser will expire cookies before seals are considered expired by the server.
-  // It also allows for clock difference of 60 seconds between server and clients.
-  return ttl - timestampSkewSec;
+	// The next line makes sure browser will expire cookies before seals are considered expired by the server.
+	// It also allows for clock difference of 60 seconds between server and clients.
+	return ttl - timestampSkewSec;
 }
 
 function getCookie(req: RequestType, cookieName: string): string {
-  return (
-    parse(
-      ("headers" in req && typeof req.headers.get === "function"
-        ? req.headers.get("cookie")
-        : (req as IncomingMessage).headers.cookie) ?? "",
-    )[cookieName] ?? ""
-  );
+	return (
+		parse(
+			("headers" in req && typeof req.headers.get === "function"
+				? req.headers.get("cookie")
+				: (req as IncomingMessage).headers.cookie) ?? "",
+		)[cookieName] ?? ""
+	);
 }
 
 function getServerActionCookie(
-  cookieName: string,
-  cookieHandler: CookieStore,
+	cookieName: string,
+	cookieHandler: CookieStore,
 ): string {
-  const cookieObject = cookieHandler.get(cookieName);
-  const cookie = cookieObject?.value;
-  if (typeof cookie === "string") {
-    return cookie;
-  }
-  return "";
+	const cookieObject = cookieHandler.get(cookieName);
+	const cookie = cookieObject?.value;
+	if (typeof cookie === "string") {
+		return cookie;
+	}
+	return "";
 }
 
 function setCookie(res: ResponseType, cookieValue: string): void {
-  if ("headers" in res && typeof res.headers.append === "function") {
-    res.headers.append("set-cookie", cookieValue);
-    return;
-  }
-  let existingSetCookie = (res as ServerResponse).getHeader("set-cookie") ?? [];
-  if (!Array.isArray(existingSetCookie)) {
-    existingSetCookie = [existingSetCookie.toString()];
-  }
-  (res as ServerResponse).setHeader("set-cookie", [
-    ...existingSetCookie,
-    cookieValue,
-  ]);
+	if ("headers" in res && typeof res.headers.append === "function") {
+		res.headers.append("set-cookie", cookieValue);
+		return;
+	}
+	let existingSetCookie = (res as ServerResponse).getHeader("set-cookie") ?? [];
+	if (!Array.isArray(existingSetCookie)) {
+		existingSetCookie = [existingSetCookie.toString()];
+	}
+	(res as ServerResponse).setHeader("set-cookie", [
+		...existingSetCookie,
+		cookieValue,
+	]);
 }
 
 export function createSealData(_crypto: Crypto) {
-  return async function sealData(
-    data: unknown,
-    {
-      password,
-      ttl = fourteenDaysInSeconds,
-    }: { password: Password; ttl?: number },
-  ): Promise<string> {
-    const passwordsMap = normalizeStringPasswordToMap(password);
+	return async function sealData(
+		data: unknown,
+		_options: { password: Password; ttl?: number },
+	): Promise<string> {
+		// Generate ML-KEM key pair with 64-byte seed
+		const kemSeed = randomBytes(64);
+		const { publicKey } = ml_kem1024.keygen(kemSeed);
 
-    const mostRecentPasswordId = Math.max(
-      ...Object.keys(passwordsMap).map(Number),
-    );
-    const passwordForSeal = {
-      id: mostRecentPasswordId.toString(),
-      secret: passwordsMap[mostRecentPasswordId]!,
-    };
+		// Encapsulate a shared secret
+		const { sharedSecret } = ml_kem1024.encapsulate(publicKey);
 
-    const seal = await ironSeal(_crypto, data, passwordForSeal, {
-      ...ironDefaults,
-      ttl: ttl * 1000,
-    });
+		// Encrypt data with AES-GCM using shared secret
+		const iv = randomBytes(12);
+		const dataBytes =
+			data instanceof Uint8Array
+				? data
+				: new TextEncoder().encode(JSON.stringify(data));
+		const encryptedData = await crypto.subtle.encrypt(
+			{
+				name: "AES-GCM",
+				iv,
+			},
+			await crypto.subtle.importKey(
+				"raw",
+				sharedSecret,
+				{ name: "AES-GCM", length: 256 },
+				false,
+				["encrypt"],
+			),
+			dataBytes,
+		);
 
-    return `${seal}${versionDelimiter}${currentMajorVersion}`;
-  };
+		// Sign the encrypted data with ML-DSA using 64-byte seed
+		const dsaSeed = randomBytes(64);
+		const { publicKey: signPublicKey, secretKey: signSecretKey } =
+			ml_dsa87.keygen(dsaSeed);
+		const signature = ml_dsa87.sign(
+			new Uint8Array(encryptedData),
+			signSecretKey,
+		);
+
+		// Combine all components
+		const seal: PQSealResult = {
+			ciphertext: base64url.stringify(new Uint8Array(encryptedData)),
+			publicKey: base64url.stringify(publicKey),
+			signature: base64url.stringify(signature),
+			signPublicKey: base64url.stringify(signPublicKey),
+		};
+
+		return `${base64url.stringify(new TextEncoder().encode(JSON.stringify(seal)))}${versionDelimiter}${currentMajorVersion}`;
+	};
 }
 
 export function createUnsealData(_crypto: Crypto) {
-  return async function unsealData<T>(
-    seal: string,
-    {
-      password,
-      ttl = fourteenDaysInSeconds,
-    }: { password: Password; ttl?: number },
-  ): Promise<T> {
-    const passwordsMap = normalizeStringPasswordToMap(password);
-    const { sealWithoutVersion, tokenVersion } = parseSeal(seal);
+	return async function unsealData<T>(
+		seal: string,
+		_options: { password: Password; ttl?: number },
+	): Promise<T> {
+		const { sealWithoutVersion, tokenVersion } = parseSeal(seal);
 
-    try {
-      const data =
-        (await ironUnseal(_crypto, sealWithoutVersion, passwordsMap, {
-          ...ironDefaults,
-          ttl: ttl * 1000,
-        })) ?? {};
+		try {
+			const sealData: PQSealResult = JSON.parse(
+				new TextDecoder().decode(
+					base64url.parse(sealWithoutVersion, { loose: true }),
+				),
+			);
 
-      if (tokenVersion === 2) {
-        return data as T;
-      }
+			// Parse the components
+			const ciphertext = base64url.parse(sealData.ciphertext);
+			const kemPublicKey = base64url.parse(sealData.publicKey);
+			const signature = base64url.parse(sealData.signature);
+			const signPublicKey = base64url.parse(sealData.signPublicKey);
 
-      // @ts-expect-error `persistent` does not exist on newer tokens
-      return { ...data.persistent } as T;
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        /^(Expired seal|Bad hmac value|Cannot find password|Incorrect number of sealed components)/.test(
-          error.message,
-        )
-      ) {
-        // if seal expired or
-        // if seal is not valid (encrypted using a different password, when passwords are badly rotated) or
-        // if we can't find back the password in the seal
-        // then we just start a new session over
-        return {} as T;
-      }
+			// Verify signature first
+			const isValid = ml_dsa87.verify(ciphertext, signature, signPublicKey);
+			if (!isValid) {
+				throw new Error("Invalid signature");
+			}
 
-      throw error;
-    }
-  };
+			// Decapsulate the shared secret
+			const sharedSecret = ml_kem1024.decapsulate(ciphertext, kemPublicKey);
+
+			// Decrypt data
+			const decryptedData = await crypto.subtle.decrypt(
+				{
+					name: "AES-GCM",
+					iv: new Uint8Array(12), // IV is included in the ciphertext
+				},
+				await crypto.subtle.importKey(
+					"raw",
+					sharedSecret,
+					{ name: "AES-GCM", length: 256 },
+					false,
+					["decrypt"],
+				),
+				ciphertext,
+			);
+
+			// Try to parse as JSON first, if it fails return as Uint8Array
+			try {
+				return JSON.parse(new TextDecoder().decode(decryptedData)) as T;
+			} catch {
+				return new Uint8Array(decryptedData) as T;
+			}
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				/^(Invalid signature|Invalid seal format|Bad hmac value|Cannot find password|Incorrect number of sealed components)/.test(
+					error.message,
+				)
+			) {
+				return {} as T;
+			}
+			throw error;
+		}
+	};
 }
 
 function getSessionConfig(
-  sessionOptions: SessionOptions,
+	sessionOptions: SessionOptions,
 ): Required<SessionOptions> {
-  const options = {
-    ...defaultOptions,
-    ...sessionOptions,
-    cookieOptions: {
-      ...defaultOptions.cookieOptions,
-      ...(sessionOptions.cookieOptions || {}),
-    },
-  };
+	const options = {
+		...defaultOptions,
+		...sessionOptions,
+		cookieOptions: {
+			...defaultOptions.cookieOptions,
+			...(sessionOptions.cookieOptions || {}),
+		},
+	};
 
-  if (
-    sessionOptions.cookieOptions &&
-    "maxAge" in sessionOptions.cookieOptions
-  ) {
-    if (sessionOptions.cookieOptions.maxAge === undefined) {
-      // session cookies, do not set maxAge, consider token as infinite
-      options.ttl = 0;
-    }
-  } else {
-    options.cookieOptions.maxAge = computeCookieMaxAge(options.ttl);
-  }
+	if (
+		sessionOptions.cookieOptions &&
+		"maxAge" in sessionOptions.cookieOptions
+	) {
+		if (sessionOptions.cookieOptions.maxAge === undefined) {
+			// session cookies, do not set maxAge, consider token as infinite
+			options.ttl = 0;
+		}
+	} else {
+		options.cookieOptions.maxAge = computeCookieMaxAge(options.ttl);
+	}
 
-  return options;
+	return options;
 }
 
 const badUsageMessage =
-  "iron-session: Bad usage: use getIronSession(req, res, options) or getIronSession(cookieStore, options).";
+	"iron-session: Bad usage: use getIronSession(req, res, options) or getIronSession(cookieStore, options).";
 
 export function createGetIronSession(
-  sealData: ReturnType<typeof createSealData>,
-  unsealData: ReturnType<typeof createUnsealData>,
+	sealData: ReturnType<typeof createSealData>,
+	unsealData: ReturnType<typeof createUnsealData>,
 ) {
-  return getIronSession;
+	return getIronSession;
 
-  async function getIronSession<T extends object>(
-    cookies: CookieStore,
-    sessionOptions: SessionOptions,
-  ): Promise<IronSession<T>>;
-  async function getIronSession<T extends object>(
-    req: RequestType,
-    res: ResponseType,
-    sessionOptions: SessionOptions,
-  ): Promise<IronSession<T>>;
-  async function getIronSession<T extends object>(
-    reqOrCookieStore: RequestType | CookieStore,
-    resOrsessionOptions: ResponseType | SessionOptions,
-    sessionOptions?: SessionOptions,
-  ): Promise<IronSession<T>> {
-    if (!reqOrCookieStore) {
-      throw new Error(badUsageMessage);
-    }
+	async function getIronSession<T extends object>(
+		cookies: CookieStore,
+		sessionOptions: SessionOptions,
+	): Promise<IronSession<T>>;
+	async function getIronSession<T extends object>(
+		req: RequestType,
+		res: ResponseType,
+		sessionOptions: SessionOptions,
+	): Promise<IronSession<T>>;
+	async function getIronSession<T extends object>(
+		reqOrCookieStore: RequestType | CookieStore,
+		resOrsessionOptions: ResponseType | SessionOptions,
+		sessionOptions?: SessionOptions,
+	): Promise<IronSession<T>> {
+		if (!reqOrCookieStore) {
+			throw new Error(badUsageMessage);
+		}
 
-    if (!resOrsessionOptions) {
-      throw new Error(badUsageMessage);
-    }
+		if (!resOrsessionOptions) {
+			throw new Error(badUsageMessage);
+		}
 
-    if (!sessionOptions) {
-      return getIronSessionFromCookieStore<T>(
-        reqOrCookieStore as CookieStore,
-        resOrsessionOptions as SessionOptions,
-        sealData,
-        unsealData,
-      );
-    }
+		if (!sessionOptions) {
+			return getIronSessionFromCookieStore<T>(
+				reqOrCookieStore as CookieStore,
+				resOrsessionOptions as SessionOptions,
+				sealData,
+				unsealData,
+			);
+		}
 
-    const req = reqOrCookieStore as RequestType;
-    const res = resOrsessionOptions as ResponseType;
+		const req = reqOrCookieStore as RequestType;
+		const res = resOrsessionOptions as ResponseType;
 
-    if (!sessionOptions) {
-      throw new Error(badUsageMessage);
-    }
+		if (!sessionOptions) {
+			throw new Error(badUsageMessage);
+		}
 
-    if (!sessionOptions.cookieName) {
-      throw new Error("iron-session: Bad usage. Missing cookie name.");
-    }
+		if (!sessionOptions.cookieName) {
+			throw new Error("iron-session: Bad usage. Missing cookie name.");
+		}
 
-    if (!sessionOptions.password) {
-      throw new Error("iron-session: Bad usage. Missing password.");
-    }
+		if (!sessionOptions.password) {
+			throw new Error("iron-session: Bad usage. Missing password.");
+		}
 
-    const passwordsMap = normalizeStringPasswordToMap(sessionOptions.password);
+		const passwordsMap = normalizeStringPasswordToMap(sessionOptions.password);
 
-    if (Object.values(passwordsMap).some((password) => password.length < 32)) {
-      throw new Error(
-        "iron-session: Bad usage. Password must be at least 32 characters long.",
-      );
-    }
+		if (Object.values(passwordsMap).some((password) => password.length < 32)) {
+			throw new Error(
+				"iron-session: Bad usage. Password must be at least 32 characters long.",
+			);
+		}
 
-    let sessionConfig = getSessionConfig(sessionOptions);
+		let sessionConfig = getSessionConfig(sessionOptions);
 
-    const sealFromCookies = getCookie(req, sessionConfig.cookieName);
-    const session = sealFromCookies
-      ? await unsealData<T>(sealFromCookies, {
-          password: passwordsMap,
-          ttl: sessionConfig.ttl,
-        })
-      : ({} as T);
+		const sealFromCookies = getCookie(req, sessionConfig.cookieName);
+		const session = sealFromCookies
+			? await unsealData<T>(sealFromCookies, {
+					password: passwordsMap,
+					ttl: sessionConfig.ttl,
+				})
+			: ({} as T);
 
-    Object.defineProperties(session, {
-      updateConfig: {
-        value: function updateConfig(newSessionOptions: SessionOptions) {
-          sessionConfig = getSessionConfig(newSessionOptions);
-        },
-      },
-      save: {
-        value: async function save() {
-          if ("headersSent" in res && res.headersSent) {
-            throw new Error(
-              "iron-session: Cannot set session cookie: session.save() was called after headers were sent. Make sure to call it before any res.send() or res.end()",
-            );
-          }
+		Object.defineProperties(session, {
+			updateConfig: {
+				value: function updateConfig(newSessionOptions: SessionOptions) {
+					sessionConfig = getSessionConfig(newSessionOptions);
+				},
+			},
+			save: {
+				value: async function save() {
+					if ("headersSent" in res && res.headersSent) {
+						throw new Error(
+							"iron-session: Cannot set session cookie: session.save() was called after headers were sent. Make sure to call it before any res.send() or res.end()",
+						);
+					}
 
-          const seal = await sealData(session, {
-            password: passwordsMap,
-            ttl: sessionConfig.ttl,
-          });
-          const cookieValue = serialize(
-            sessionConfig.cookieName,
-            seal,
-            sessionConfig.cookieOptions,
-          );
+					const seal = await sealData(session, {
+						password: passwordsMap,
+						ttl: sessionConfig.ttl,
+					});
+					const cookieValue = serialize(
+						sessionConfig.cookieName,
+						seal,
+						sessionConfig.cookieOptions,
+					);
 
-          if (cookieValue.length > 4096) {
-            throw new Error(
-              `iron-session: Cookie length is too big (${cookieValue.length} bytes), browsers will refuse it. Try to remove some data.`,
-            );
-          }
+					if (cookieValue.length > 4096) {
+						throw new Error(
+							`iron-session: Cookie length is too big (${cookieValue.length} bytes), browsers will refuse it. Try to remove some data.`,
+						);
+					}
 
-          setCookie(res, cookieValue);
-        },
-      },
+					setCookie(res, cookieValue);
+				},
+			},
 
-      destroy: {
-        value: function destroy() {
-          Object.keys(session).forEach((key) => {
-            delete (session as Record<string, unknown>)[key];
-          });
-          const cookieValue = serialize(sessionConfig.cookieName, "", {
-            ...sessionConfig.cookieOptions,
-            maxAge: 0,
-          });
+			destroy: {
+				value: function destroy() {
+					for (const key of Object.keys(session)) {
+						delete (session as Record<string, unknown>)[key];
+					}
+					const cookieValue = serialize(sessionConfig.cookieName, "", {
+						...sessionConfig.cookieOptions,
+						maxAge: 0,
+					});
 
-          setCookie(res, cookieValue);
-        },
-      },
-    });
+					setCookie(res, cookieValue);
+				},
+			},
+		});
 
-    return session as IronSession<T>;
-  }
+		return session as IronSession<T>;
+	}
 }
 
 async function getIronSessionFromCookieStore<T extends object>(
-  cookieStore: CookieStore,
-  sessionOptions: SessionOptions,
-  sealData: ReturnType<typeof createSealData>,
-  unsealData: ReturnType<typeof createUnsealData>,
+	cookieStore: CookieStore,
+	sessionOptions: SessionOptions,
+	sealData: ReturnType<typeof createSealData>,
+	unsealData: ReturnType<typeof createUnsealData>,
 ): Promise<IronSession<T>> {
-  if (!sessionOptions.cookieName) {
-    throw new Error("iron-session: Bad usage. Missing cookie name.");
-  }
+	if (!sessionOptions.cookieName) {
+		throw new Error("iron-session: Bad usage. Missing cookie name.");
+	}
 
-  if (!sessionOptions.password) {
-    throw new Error("iron-session: Bad usage. Missing password.");
-  }
+	if (!sessionOptions.password) {
+		throw new Error("iron-session: Bad usage. Missing password.");
+	}
 
-  const passwordsMap = normalizeStringPasswordToMap(sessionOptions.password);
+	const passwordsMap = normalizeStringPasswordToMap(sessionOptions.password);
 
-  if (Object.values(passwordsMap).some((password) => password.length < 32)) {
-    throw new Error(
-      "iron-session: Bad usage. Password must be at least 32 characters long.",
-    );
-  }
+	if (Object.values(passwordsMap).some((password) => password.length < 32)) {
+		throw new Error(
+			"iron-session: Bad usage. Password must be at least 32 characters long.",
+		);
+	}
 
-  let sessionConfig = getSessionConfig(sessionOptions);
-  const sealFromCookies = getServerActionCookie(
-    sessionConfig.cookieName,
-    cookieStore,
-  );
-  const session = sealFromCookies
-    ? await unsealData<T>(sealFromCookies, {
-        password: passwordsMap,
-        ttl: sessionConfig.ttl,
-      })
-    : ({} as T);
+	let sessionConfig = getSessionConfig(sessionOptions);
+	const sealFromCookies = getServerActionCookie(
+		sessionConfig.cookieName,
+		cookieStore,
+	);
+	const session = sealFromCookies
+		? await unsealData<T>(sealFromCookies, {
+				password: passwordsMap,
+				ttl: sessionConfig.ttl,
+			})
+		: ({} as T);
 
-  Object.defineProperties(session, {
-    updateConfig: {
-      value: function updateConfig(newSessionOptions: SessionOptions) {
-        sessionConfig = getSessionConfig(newSessionOptions);
-      },
-    },
-    save: {
-      value: async function save() {
-        const seal = await sealData(session, {
-          password: passwordsMap,
-          ttl: sessionConfig.ttl,
-        });
+	Object.defineProperties(session, {
+		updateConfig: {
+			value: function updateConfig(newSessionOptions: SessionOptions) {
+				sessionConfig = getSessionConfig(newSessionOptions);
+			},
+		},
+		save: {
+			value: async function save() {
+				const seal = await sealData(session, {
+					password: passwordsMap,
+					ttl: sessionConfig.ttl,
+				});
 
-        const cookieLength =
-          sessionConfig.cookieName.length +
-          seal.length +
-          JSON.stringify(sessionConfig.cookieOptions).length;
+				const cookieLength =
+					sessionConfig.cookieName.length +
+					seal.length +
+					JSON.stringify(sessionConfig.cookieOptions).length;
 
-        if (cookieLength > 4096) {
-          throw new Error(
-            `iron-session: Cookie length is too big (${cookieLength} bytes), browsers will refuse it. Try to remove some data.`,
-          );
-        }
+				if (cookieLength > 4096) {
+					throw new Error(
+						`iron-session: Cookie length is too big (${cookieLength} bytes), browsers will refuse it. Try to remove some data.`,
+					);
+				}
 
-        cookieStore.set(
-          sessionConfig.cookieName,
-          seal,
-          sessionConfig.cookieOptions,
-        );
-      },
-    },
+				cookieStore.set(
+					sessionConfig.cookieName,
+					seal,
+					sessionConfig.cookieOptions,
+				);
+			},
+		},
 
-    destroy: {
-      value: function destroy() {
-        Object.keys(session).forEach((key) => {
-          delete (session as Record<string, unknown>)[key];
-        });
+		destroy: {
+			value: function destroy() {
+				for (const key of Object.keys(session)) {
+					delete (session as Record<string, unknown>)[key];
+				}
 
-        const cookieOptions = { ...sessionConfig.cookieOptions, maxAge: 0 };
-        cookieStore.set(sessionConfig.cookieName, "", cookieOptions);
-      },
-    },
-  });
+				const cookieOptions = { ...sessionConfig.cookieOptions, maxAge: 0 };
+				cookieStore.set(sessionConfig.cookieName, "", cookieOptions);
+			},
+		},
+	});
 
-  return session as IronSession<T>;
+	return session as IronSession<T>;
 }


### PR DESCRIPTION
Recently I attended a conference talking about secure implementation's regarding PQC Encryption, due to the latest trends and also the threat of data harvesting I decided to try and rewrite an implementation of the iron-session lib which uses post quantum encryption under the hood, and falls back to iron-seal if not, this prevents any data harvesting risk and decryption for when quantum computers become more available. Under the hood the session uses ML-KEM1024 (formerly known as Kyber-1024), a NIST-approved post-quantum key encapsulation mechanism, which provides 256-bit security that's resistant to attacks from quantum computers, it also uses AES-GCM for symmetric encryption after secure key exchange. This is very much a work in progress, this is the first working build I have which passes every test:
```ts
ℹ tests 24
ℹ suites 0
ℹ pass 24
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 159.677417
```
I have tried to update the README as much as possible, and also added a "When to use it" section. Any feedback or advice would be brilliant.